### PR TITLE
edit archetypes/default.md for Hugo v0.24 or above

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,4 +1,7 @@
 ---
 categories:
   - Others
+title: "{{ replace .TranslationBaseName "-" " " | title }}"
+date: {{ .Date }}
+draft: true
 ---


### PR DESCRIPTION
To solve #14 for Hugo v0.24 or above when use `hugo new` to create new posts. It refers to the prompt by Hugo v0.25.1.