### PR TITLE
Remove automatic trimming for navmenu

### DIFF
--- a/layouts/partials/nav/menus/main.html
+++ b/layouts/partials/nav/menus/main.html
@@ -3,9 +3,9 @@
     {{ range .Site.Menus.main }}
     <li>
       <a href='{{ .URL }}' 
-        {{- if or ( $.IsMenuCurrent "main" . ) ( $.HasMenuCurrent "main" . ) -}}
-          class='current' aria-current='page'
-        {{- end -}}
+        {{ if or ( $.IsMenuCurrent "main" . ) ( $.HasMenuCurrent "main" . ) }}
+           class='current' aria-current='page'
+        {{ end }}
       >
         {{- .Name -}}
       </a>


### PR DESCRIPTION
This theme is excellent, the only issue is that a missing space is creating a single error and making it w3c non-compliant. You can check it at https://validator.w3.org .