### PR TITLE
Add check to RSSLink variable

### DIFF
--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -2,6 +2,9 @@
   {{ partial "head/meta" . }}
   <title>{{ partial "data/title" . }}</title>
   <link rel='canonical' href='{{ .Permalink }}'>
-  <link href='{{ .RSSLink }}' rel='alternate' type='application/rss+xml' title='{{ .Site.Title }}' />
+  {{ if .RSSLink }}
+    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+  {{ end }}
   {{ partial "head/includes" . }}
 </head>


### PR DESCRIPTION
w/o the nil check, Hugo would generate useless rss link in post like:
```
<link href='' rel='alternate' type='application/rss+xml' title='site title' />
```

Change the template according to https://gohugo.io/templates/rss/#reference-your-rss-feed-in-head