### PR TITLE
Use dateFormat param when rendering li

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -3,7 +3,7 @@
     <span>
       <span class='screen-reader'>{{ i18n "postedOn" }} </span>
       <time datetime='{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}'>
-        {{- .Date.Format "2006, Jan 02" -}}
+        {{- .Date.Format ( or .Site.Params.dateFormat "2006, Jan 02" ) -}}
       </time>
     </span>
   </div>


### PR DESCRIPTION
Noticed that the `dateFormat` param I set in the config file wasn't being used in the list of entries on the homepage. 