### PR TITLE
Fix for forestry.io import problem.

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,7 +1,7 @@
 ---
 categories:
   - Others
-title: "{{ replace .TranslationBaseName "-" " " | title }}"
-date: {{ .Date }}
+title: "{{ replace .TranslationBaseName '-' ' ' | title }}"
+date: "{{ .Date }}"
 draft: true
 ---


### PR DESCRIPTION
Conversation from forestry.io support (Chris):

> This looks like it may be an issue with a Hugo archetype. In Hugo 0.24, Hugo added support for GoTemplate language in archetypes, but this violates the TOML & YAML specification and can cause import errors in Forestry.
> This can be resolved by ensuring GoTemplate language is inside a string, and making sure that the string isn't ended inside the GoTemplate language.
> In your case, updating your "default" archetype as follows will fix this:
> ---
> title: "{{ replace .TranslationBaseName '-' ' ' | title }}"
> date: "{{ .Date }}"
> ---
