### PR TITLE
Use the dateFormat parameter for post date in post list

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -3,7 +3,7 @@
     <span>
       <span class='screen-reader'>{{ i18n "postedOn" }} </span>
       <time datetime='{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}'>
-        {{- .Date.Format "2006, Jan 02" -}}
+        {{- .Date.Format ( or .Site.Params.dateFormat "2006, Jan 02" ) -}}
       </time>
     </span>
   </div>


### PR DESCRIPTION
Hi,

It is a simple fix to use the dateFormat parameter in post list instead have a hard coded format date in post list. 