### PR TITLE
Fixed defaultContentLanguage setting in example site

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -14,6 +14,9 @@ preserveTaxonomyNames = true
 # Syntax Highlighting ( https://gohugo.io/content-management/syntax-highlighting/ )
 pygmentsCodefences = true
 
+# Language Configuration
+defaultContentLanguage = "en"
+
 [params.info]
 description = "Minimalist theme for Hugo"
 title404 = "Nothing's here!"
@@ -71,9 +74,6 @@ url = "https://github.com/MunifTanjim/minimo"
 
 [blackfriday]
 hrefTargetBlank = true
-
-# Language Configuration
-defaultContentLanguage = "en"
 
 [languages]
 # edit this block for your own language


### PR DESCRIPTION
Solves and issue of setting the default language not working exampleSize .toml file. See issue I just opened. #37 