### PR TITLE
Run paths to CSS and JS through relURL.

### DIFF
--- a/layouts/partials/footer/scripts.html
+++ b/layouts/partials/footer/scripts.html
@@ -1,4 +1,4 @@
-<script src='{{ print "/assets/js/" .Site.Data.assets.main.js }}'></script>
+<script src='{{ print "/assets/js/" .Site.Data.assets.main.js | relURL }}'></script>
 
 {{- range .Site.Params.assets.customJS -}}
   <script src='{{ . | relURL }}'></script>

--- a/layouts/partials/head/includes.html
+++ b/layouts/partials/head/includes.html
@@ -1,6 +1,6 @@
 <link rel='icon' href='{{ ( or .Site.Params.assets.favicon "favicon.ico" ) | relURL }}'>
 <link rel='stylesheet' href='https://fonts.googleapis.com/css?family=Ubuntu:400,400i,700&subset=latin'>
-<link rel='stylesheet' href='{{ print "/assets/css/" .Site.Data.assets.main.css }}'>
+<link rel='stylesheet' href='{{ print "/assets/css/" .Site.Data.assets.main.css | relURL  }}'>
 
 {{- range .Site.Params.assets.customCSS -}}
   <link rel='stylesheet' href='{{ . | relURL }}'>


### PR DESCRIPTION
This prevents problems when the baseURL contains a subdirectory (e.g., https://example.com/hugo/).