### PR TITLE
markdownify footer content to process hyperlinks.

### DIFF
--- a/layouts/partials/footer/copyright.html
+++ b/layouts/partials/footer/copyright.html
@@ -11,7 +11,7 @@
         {{ end }}
       {{ end }}
 
-      {{ .prefix }} &copy; {{ with ( $.Scratch.Get "copyrightStartYear" ) }}{{ . }}-{{ end }}{{ now.Year }} {{ or .holder $.Site.Title }} {{ .suffix }}
+      {{ .prefix | markdownify }} &copy; {{ with ( $.Scratch.Get "copyrightStartYear" ) }}{{ . }}-{{ end }}{{ now.Year }} {{ or .holder $.Site.Title | markdownify }} {{ .suffix | markdownify }}
     {{- end -}}
   {{ end }}
   </p>


### PR DESCRIPTION
It was not possible to include links in the footer, since all of the content from the `config` variables `[params.copyright] > prefix|holder|suffix` were sanitized. This commit adds a simple preprocessing function `markdownify` that enables a user to add links in markdown format.

I personally feel its quite common to have links in the footer of many pages - and hence added this functionality. Attached are before and after views.

**Before:**
<img width="1236" alt="before" src="https://user-images.githubusercontent.com/859719/34906475-8c69bb06-f87f-11e7-9b21-f5665faa8a8b.png">
**After:**
<img width="1238" alt="after" src="https://user-images.githubusercontent.com/859719/34906476-8c914ee6-f87f-11e7-8e95-7b50fc04f43c.png">

