### PR TITLE
fix [templates]: Sidebar logo needs BaseURL

### DIFF
--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -8,7 +8,7 @@
     {{ with $config.logo }}
     <div class='logo'>
       <a href='{{ $.Site.BaseURL | relURL }}'>
-        <img src='{{ . }}'>
+        <img src='{{ . | relURL }}'>
       </a>
     </div>
     {{ end }}


### PR DESCRIPTION
When a site is being hosted from a subdirectory the sidebar logo src needs the Site.BaseURL in order to resolve properly.

Just beginning to learn Hugo so let me know if there is a better way to handle this. 

I also wondered if it would good to support vernacular site logos in the future for users that offer their content in multiple languages. 

Thanks