### PR TITLE
fix social.base expected value found '\'

### DIFF
--- a/data/theme.toml
+++ b/data/theme.toml
@@ -1,12 +1,12 @@
 [social.base]
-codepen = 'https://codepen.io/'
-email =  'mailto:'
-facebook = 'https://facebook.com/'
-github = 'https://github.com/'
-gitlab = 'https://gitlab.com/'
-instagram = 'https://instagram.com/'
-linkedin = 'https://linkedin.com/in/'
-twitter = 'https://twitter.com/'
-telegram = 'https://t.me/'
-google_scholar = 'https://scholar.google.com/citations?user='
-youtube = 'https://www.youtube.com/channel/'
+codepen = "https://codepen.io/"
+email =  "mailto:"
+facebook = "https://facebook.com/"
+github = "https://github.com/"
+gitlab = "https://gitlab.com/"
+instagram = "https://instagram.com/"
+linkedin = "https://linkedin.com/in/"
+twitter = "https://twitter.com/"
+telegram = "https://t.me/"
+google_scholar = "https://scholar.google.com/citations?user="
+youtube = "https://www.youtube.com/channel/"


### PR DESCRIPTION
Single quotes caused a minor error displaying the following message.
Building sites … ERROR 2018/06/19 10:34:05 Failed to read data from theme.toml/theme.toml:
Near line 2, key 'social.base.codepen': Near line 2: Expected value but found '\'' instead.

Changing single quotes to double quotes fixed the error.

closes #150