### PR TITLE
(WIP) (GH-125) Add categories to recent posts

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -9,4 +9,9 @@
       </a>
     </h3>
   </header>
+  {{ if (isset .Params.Categories 0) }}
+  <div>
+    {{- partial "svg/icons" "category" -}} {{ range first 1 .Params.Categories }} {{ . }} {{ end }}
+  </div>
+  {{ end }}
 </li>


### PR DESCRIPTION
Prior to this commit the recent posts pagination page
would list the posts but give the viewer no way to
distinguish between types of posts or categories -
so, for example, without following the link the user
has no way to distinguish between a poem and a blog
post.

This commit makes minimal additions to the li partial
to ensure that when a page is added, the first category
listed for that page, if any, is also listed.