### PR TITLE
add [feature]: isso comment system

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -85,6 +85,12 @@ youtube = "UCT-U0rNerYxItGcuoPX-WYA"
 [params.comments]
 enable = false
 
+# Isso: https://posativ.org/isso/
+[params.comments.isso]
+enable = false
+scriptSrc = "" # "https://isso.example.com/js/embed.min.js"
+dataAttrs = "" # "data-isso='https://isso.example.com' data-isso-require-author='true'"
+
 [params.comments.staticman]
 enable = true
 apiEndpoint = "https://api.staticman.net/v2/entry"

--- a/exampleSite/content/docs/comments-support.md
+++ b/exampleSite/content/docs/comments-support.md
@@ -43,7 +43,7 @@ _Of course, you'll also need to setup a comment system ( [Disqus](#disqus) or [S
 
 ## Setting Up Comment System
 
-Minimo currently supports **[Disqus](https://disqus.com/)**, **[Staticman](https://staticman.net/)** and **[Utterances](https://utteranc.es)** to be used as your site's comment system.
+Minimo currently supports **[Disqus](https://disqus.com/)**, **[Isso](https://posativ.org/isso/)**, **[Staticman](https://staticman.net/)** and **[Utterances](https://utteranc.es)** to be used as your site's comment system.
 
 ### Disqus
 
@@ -56,6 +56,22 @@ disqusShortname = ""
 - `disqusShortname` [`String`]: Shortname for you site's Disqus account
 
 And that's all!
+
+### Isso
+
+Isso is a lightweight alternative to Disqus. You need to have a Isso server running somewhere, then set up the following options in your `config.toml` file:
+
+```toml
+[params.comments.isso]
+enable = true
+scriptSrc = "https://isso.example.com/js/embed.min.js"
+dataAttrs = "data-isso='https://isso.example.com data-isso-require-author='true'"
+```
+
+- `params.comments.isso` [`Map`]:
+  - `enable` [`Boolean`]: Enable Isso
+  - `scriptSrc` [`String`]: URL of the Isso integration script.
+  - `dataAttrs` [`String`]: Data attributes to add to the Isso `<script>` tag. Optional, but the Isso documentation recommends to at least include the `data-isso` attribute.
 
 ### Staticman
 

--- a/layouts/partials/comments/isso.html
+++ b/layouts/partials/comments/isso.html
@@ -1,3 +1,6 @@
-<script{{- with .Page.Site.Params.comments.isso.dataAttrs }} {{ . | safeHTMLAttr }} {{ end -}}
-        src="{{ .Page.Site.Params.comments.isso.scriptSrc }}"></script>
-<section id="isso-thread"></section>
+{{- $scriptSrc := .Page.Site.Params.comments.isso.scriptSrc -}}
+{{- $dataAttrs := .Page.Site.Params.comments.isso.dataAttrs -}}
+
+<script src='{{ $scriptSrc }}' {{- with $dataAttrs }} {{ . | safeHTMLAttr }} {{- end -}}></script>
+
+<section id='isso-thread'></section>

--- a/layouts/partials/comments/isso.html
+++ b/layouts/partials/comments/isso.html
@@ -1,0 +1,3 @@
+<script{{- with .Page.Site.Params.comments.isso.dataAttrs }} {{ . | safeHTMLAttr }} {{ end -}}
+        src="{{ .Page.Site.Params.comments.isso.scriptSrc }}"></script>
+<section id="isso-thread"></section>

--- a/layouts/partials/entry/comments.html
+++ b/layouts/partials/entry/comments.html
@@ -12,15 +12,18 @@
 {{- if ( or $enableConditionOne $enableConditionTwo ) -}}
 
 {{- $disqusEnabled := .Site.DisqusShortname -}}
+{{- $issoEnabled := $config.isso.enable -}}
 {{- $staticmanEnabled := $config.staticman.enable -}}
 {{- $utterancesEnabled := $config.utterances.enable -}}
 
-{{- if ( $disqusEnabled | or $staticmanEnabled | or $utterancesEnabled ) -}}
+{{- if ( $disqusEnabled | or $issoEnabled | or $staticmanEnabled | or $utterancesEnabled ) -}}
 <section id='comments' class='comments'>
   <div class='container sep-before'>
     <div class='comments-area'>
     {{- if $disqusEnabled -}}
       {{ partial "comments/disqus" . }}
+    {{- else if $issoEnabled -}}
+      {{ partial "comments/isso" . }}
     {{- else if $staticmanEnabled -}}
       {{ partial "comments/staticman" . }}
     {{- else if $utterancesEnabled -}}

--- a/theme.toml
+++ b/theme.toml
@@ -19,6 +19,7 @@ features = [
   "entry-navigation",
   "favicon",
   "fuse.js",
+  "isso",
   "lunr.js",
   "multilingual",
   "multi-author",


### PR DESCRIPTION
This PR adds support for Isso, an open source, self-hosted alternative to Disqus. (If you don't want to setup your own instance, you can use https://comment.sh/)