### PR TITLE
add [feature]: noMetaSections

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -43,6 +43,7 @@ dateFormat = "2006, Jan 02"
 listDateFormat = "2006, Jan 02"
 archiveDateFormat = "Jan 02"
 hideEntryNavigation = ["page"] # boolean / array of sections
+hideEntryMeta = ["page"] # boolean / array of sections
 showReadingTime = true
 showLastmod = true
 taxonomyCloudShuffle = true

--- a/layouts/partials/entry/meta.html
+++ b/layouts/partials/entry/meta.html
@@ -1,4 +1,14 @@
-{{ if not ( eq .Section "page" ) }}
+{{- $defaultConfig := slice "page" -}}
+{{- $config := .Site.Params.settings.hideEntryMeta | default $defaultConfig -}}
+{{- $configType := ( printf "%T" $config ) -}}
+
+{{- if ( eq $configType "bool" ) -}}
+  {{- $.Scratch.Set "showEntryMeta" ( not $config ) -}}
+{{- else -}}
+  {{- $.Scratch.Set "showEntryMeta" ( not ( in $config .Section ) ) -}}
+{{- end -}}
+
+{{- if ( $.Scratch.Get "showEntryMeta" ) -}}
 <div class='entry-meta'>
   {{ partial "entry/meta/posted-on" . }}
   {{ partial "entry/meta/author" . }}


### PR DESCRIPTION
Instead of only hiding meta (date, reading time…) on pages, hide them for sections listed in a configurable array named `noMetaSections`. Defaults to `["page"]` for backward compatibility.

This is useful if a site includes several types of sections. For instance I'm working on a `portfolio` section, and I don't want to include a date or reading time on these pages. This makes this behaviour possible and simple to achieve without overriding a partial from the theme.