### PR TITLE
enhance [templates]: hide date if not set

### DIFF
--- a/layouts/partials/entry/meta/posted-on.html
+++ b/layouts/partials/entry/meta/posted-on.html
@@ -1,8 +1,10 @@
-{{- $dateFormat := ( .Site.Params.settings.dateFormat | default "2006, Jan 02" ) -}}
-<span class='posted-on'>
-  {{- partial "svg/icons" "calendar" -}}
-  <span class='screen-reader-text'>{{ i18n "postedOn" }} </span>
-  <time class='entry-date' datetime='{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}'>
-    {{- .Date.Format $dateFormat -}}
-  </time>
-</span>
+{{ if isset .Params "date" }}
+  {{- $dateFormat := ( .Site.Params.settings.dateFormat | default "2006, Jan 02" ) -}}
+  <span class='posted-on'>
+    {{- partial "svg/icons" "calendar" -}}
+    <span class='screen-reader-text'>{{ i18n "postedOn" }} </span>
+    <time class='entry-date' datetime='{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}'>
+      {{- .Date.Format $dateFormat -}}
+    </time>
+  </span>
+{{ end }}


### PR DESCRIPTION
I don't want to set a post date for all content, and I'm sure nobody needs those "0001-01-01" dates. This hides the posted-on element if date is not set.