### PR TITLE
Max width on medium breakpoint

### DIFF
--- a/src/stylesheets/layouts/_layouts.scss
+++ b/src/stylesheets/layouts/_layouts.scss
@@ -13,7 +13,7 @@
   }
 
   @include screen($breakpoint-medium) {
-    width: auto;
+    width: 100%;
 
     .has-sidebar & {
       float: left;


### PR DESCRIPTION
This fixes an issue where `.main` will not always occupy 100% width of the parent container.

For example:
![image](https://user-images.githubusercontent.com/6129517/56097319-13ee2380-5f10-11e9-9e5d-cf956cbf2690.png)

Post `with: 100%`:
![image](https://user-images.githubusercontent.com/6129517/56097330-36803c80-5f10-11e9-9c35-a7d1e3b1e334.png)

I can't run the built script to generate minified CSS files since my setup is quite different.