### PR TITLE
Remove deprecated Page.Hugo usage

### DIFF
--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -5,4 +5,4 @@
 
 {{ partial "head/opengraph" . }}
 
-{{ .Hugo.Generator }}
+{{ hugo.Generator }}


### PR DESCRIPTION
See https://discourse.gohugo.io/t/pages-hugo-is-deprecated-as-of-0-55-0/17991

Without this change, I get the deprecation warning. With the change, no warning and the generator meta tag is still replaced correctly. :)