### PR TITLE
Update german translation for recentPosts

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -96,7 +96,7 @@ one = "Eine Minute Lesezeit"
 other = "{{ .Count }} Minuten Lesezeit"
 
 [recentPosts]
-other = "Vorherige Beiträge"
+other = "Aktuelle Beiträge"
 
 [skipToContent]
 other = "Zum Inhalt springen"


### PR DESCRIPTION
"recent" translates to "kürzlich" or "aktuell" not "Vorherige" as in previous.

Without that change people visiting the homepage of a site are puzzled because there is no recent article shown but the header implies it.