### PR TITLE
Updates serialize-javascript version (Closes https://github.com/MunifTanjim/minimo/issues/255)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7278,7 +7278,7 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "serialize-javascript": {
-      "version": "1.7.0",
+      "version": ">=2.1.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
       "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
       "dev": true


### PR DESCRIPTION
This PR updates the version of `serialize-javascript` to address potentila security vulnerability.

Feel free to absorb or modify `>=` to `=` to control the version, the update fixed the alert for me.

Thank you for such a complete theme, much appreciated!

Cheers,
Christina