### PR TITLE
Add Google Analytics tags in theme.toml

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -7,7 +7,8 @@ tags = [
   "blog",
   "minimal",
   "minimalist",
-  "responsive"
+  "responsive",
+  "google-analytics"
 ]
 features = [
   "accessibility",


### PR DESCRIPTION
- It might be help to understand about minimo provide Google Analytics features.
- After add this tags,
minimo display here!
https://themes.gohugo.io/tags/google-analytics/