### PR TITLE
misspell [translation] en, add [translation] id, enhance [template] permalink /search

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -22,7 +22,7 @@ other = "Categories"
 other = "Comment"
 
 [commentSubmissionErrorMessage]
-other = "Error occured. Couldn't submit your comment. Please try again. Thank You!"
+other = "Error occurred. Couldn't submit your comment. Please try again. Thank You!"
 
 [commentSubmissionErrorTitle]
 other = "Yikes, Sorry!"

--- a/i18n/id.toml
+++ b/i18n/id.toml
@@ -1,0 +1,155 @@
+[author]
+one = "Pengarang"
+other = "Pengarang"
+
+[authorsAvatar]
+other = "Avatar {{ .Author }}"
+
+[by]
+other = "oleh"
+
+[cancel]
+other = "Batal"
+
+[cancelComment]
+other = "Batal menanggapi"
+
+[category]
+one = "Kategori"
+other = "Kategori"
+
+[comment]
+other = "Tanggapan"
+
+[commentSubmissionErrorMessage]
+other = "Terdapat galat. Tidak dapat mengirim tanggapanmu. Silakan coba lagi. Terima kasih."
+
+[commentSubmissionErrorTitle]
+other = "Oops, maaf."
+
+[commentSubmissionSuccessMessage]
+other = "Tanggapanmu telah dikirim dan akan segera muncul di laman ini."
+
+[commentSubmissionSuccessTitle]
+other = "Terima kasih."
+
+[commentsOnEntry]
+one = "Hanya terdapat {{ .Count }} tanggapan di {{ .Title }}"
+other = "Terdapat {{ .Count }} tanggapan di {{ .Title }}"
+
+[contactViaEmail]
+other = "Hubungi melalui Surel"
+
+[currentPage]
+other = "Laman saat ini"
+
+[email]
+other = "Surel"
+
+[gopher]
+other = "Gopher"
+
+[goHome]
+other = "Ke Beranda..."
+
+[lastUpdated]
+other = "Pembaruan terakhir"
+
+[leaveAComment]
+other = "Tinggalkan tanggapan"
+
+[mainMenu]
+other = "Menu Utama"
+
+[name]
+other = "Nama"
+
+[next]
+other = "Selanjutnya"
+
+[nextPage]
+other = "Laman selanjutnya"
+
+[nextPost]
+other = "Pos Selanjutnya"
+
+[noTerm]
+other = "Tidak ada satu pun {{ .Term }}!"
+
+[ok]
+other = "Oke"
+
+[openAccountInNewTab]
+other = "Buka akun {{ .Platform }} di tab baru"
+
+[page]
+other = "Laman"
+
+[previous]
+other = "Sebelumnya"
+
+[previousPage]
+other = "Laman sebelumnya"
+
+[previousPost]
+other = "Pos sebelumnya"
+
+[postedOn]
+other = "Diposkan pada"
+
+[readingTime]
+one = "1 menit membaca"
+other = "{{ .Count }} menit membaca"
+
+[recentPosts]
+other = "Pos Terakhir"
+
+[reply]
+other = "Balas"
+
+[replyToAuthor]
+other = "Balas kepada {{ .Author }}"
+
+[says]
+other = "mengatakan"
+
+[search]
+other = "Cari"
+
+[searchResultEmpty]
+other = "Tidak ditemukan"
+
+[searching]
+other = "Mencari"
+
+[series]
+one = "Seri"
+other = "Seri"
+
+[sidebarMenu]
+other = "Menu Sisi"
+
+[skipToContent]
+other = "Lompat ke konten"
+
+[skipToMainMenu]
+other = "Lompat ke Menu Utama"
+
+[socialMenu]
+other = "Menu Sosial"
+
+[submitComment]
+other = "Taggapi"
+
+[tableOfContents]
+other = "Daftar Isi"
+
+[tag]
+one = "Label"
+other = "Label"
+
+[toggleSidebar]
+other = "Buka/Tutup Bilah Sisi"
+
+[website]
+other = "Situs web"

--- a/layouts/partials/widgets/search.html
+++ b/layouts/partials/widgets/search.html
@@ -10,7 +10,7 @@
     </h4>
   </header>
 
-  <form action='{{ "search" | relLangURL }}' id='search-form' class='search-form'>
+  <form action='{{ ( or .Site.Permalinks.search "search" ) | relLangURL }}' id='search-form' class='search-form'>
     <label>
       <span class='screen-reader-text'>{{ i18n "search" }}</span>
       <input id='search-term' class='search-term' type='search' name='q' placeholder='{{ i18n "search" }}&hellip;'>


### PR DESCRIPTION
### Misspell [translation]: en.toml
on 
```toml
[commentSubmissionErrorMessage]
other = "Error occurred. Couldn't submit your comment. Please try again. Thank You!"
```
**eccured** is misspell, the correct spelling is **occurred**

### Added [translation]: id.toml
Because I use this theme for my blog that supports Indonesian Language, so I made translation for Bahasa Indonesia.

### Enhance [template]: permalink search
After I changed my blog into Indonesian Language, only one hasn't. The permalink when you submit search form.

Permalink before   `/search?q=`
```html
<form action='{{ ( or .Site.Permalinks.search "search" ) | relLangURL }}' id='search-form' class='search-form'>
```
You can set permalink in config.toml
```toml
[permalinks]
page = "/:slug/"
search = "/cari"
```
Permalink after `/cari?q=`