### PR TITLE
Add customization for search permalink

### DIFF
--- a/layouts/partials/widgets/search.html
+++ b/layouts/partials/widgets/search.html
@@ -10,7 +10,7 @@
     </h4>
   </header>
 
-  <form action='{{ "search" | relLangURL }}' id='search-form' class='search-form'>
+  <form action='{{ ( or .Site.Permalinks.search "search" ) | relLangURL }}' id='search-form' class='search-form'>
     <label>
       <span class='screen-reader-text'>{{ i18n "search" }}</span>
       <input id='search-term' class='search-term' type='search' name='q' placeholder='{{ i18n "search" }}&hellip;'>


### PR DESCRIPTION
Permalink before   `/search?q=`

With this, you can set permalink in config.toml
```toml
[permalinks]
page = "/:slug/"
search = "/cari"
```
Permalink after `/cari?q=`