### PR TITLE
Added Additional Utterances Options

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -104,6 +104,8 @@ repository = "minimo"
 [params.comments.utterances]
 enable = false
 issueTerm = "pathname" # pathname / url / title
+label = ""
+theme = ""
 
 [params.comments.utterances.github]
 username = "MunifTanjim"

--- a/exampleSite/content/docs/comments-support.md
+++ b/exampleSite/content/docs/comments-support.md
@@ -141,7 +141,7 @@ repository = "minimo"
   - `enable` [`Boolean`]: Enable Utterances
   - `issueTerm` [`String`]: Entry to Issue mapping option _(`pathname` / `url` / `title`)_
   - `theme` [`String`]: Sets a theme for Utterances comments. See _[utteranc.es](https://utteranc.es)_ for available themes
-  - `label` [`String`]: Tells Utterances-bot to set an issue label for every new issue it creates for comments.
+  - `label` [`String`]: Tells Utterances-bot to set an issue label for every new issue it creates for comments
 - `params.comments.utterances.github` [`Map`]:
   - `username` [`String`]: Your GitHub Username
   - `repository` [`String`]: Name of your Site's GitHub Repository

--- a/exampleSite/content/docs/comments-support.md
+++ b/exampleSite/content/docs/comments-support.md
@@ -129,6 +129,8 @@ For using Utterances, set up the following options in your `config.toml` file:
 [params.comments.utterances]
 enable = true
 issueTerm = "pathname" # pathname / url / title
+theme = ""
+label = ""
 
 [params.comments.utterances.github]
 username = "MunifTanjim"
@@ -138,6 +140,8 @@ repository = "minimo"
 - `params.comments.utterances` [`Map`]:
   - `enable` [`Boolean`]: Enable Utterances
   - `issueTerm` [`String`]: Entry to Issue mapping option _(`pathname` / `url` / `title`)_
+  - `theme` [`String`]: Sets a theme for Utterances comments. See _[utteranc.es](https://utteranc.es)_ for available themes
+  - `label` [`String`]: Tells Utterances-bot to set an issue label for every new issue it creates for comments.
 - `params.comments.utterances.github` [`Map`]:
   - `username` [`String`]: Your GitHub Username
   - `repository` [`String`]: Name of your Site's GitHub Repository

--- a/layouts/partials/comments/utterances.html
+++ b/layouts/partials/comments/utterances.html
@@ -4,12 +4,16 @@
 {{- $issueLabel := .Page.Site.Params.comments.utterances.issueLabel -}}
 {{- $username := .Page.Site.Params.comments.utterances.github.username -}}
 {{- $repository := .Page.Site.Params.comments.utterances.github.repository -}}
+{{- $theme := .Page.Site.Params.comments.utterances.theme -}}
 
 <script src='{{ $scriptSrc }}'
   repo='{{ print $username "/" $repository }}'
   issue-term='{{ $issueTerm }}'
   {{- if $issueLabel -}}
     label='{{ $issueLabel }}'
+  {{- end -}}
+  {{- if $theme -}}
+    theme="{{ $theme }}"
   {{- end -}}
   crossorigin='anonymous' async>
 </script>

--- a/layouts/partials/comments/utterances.html
+++ b/layouts/partials/comments/utterances.html
@@ -1,10 +1,15 @@
 {{- $scriptSrc := "https://utteranc.es/client.js" -}}
 
 {{- $issueTerm := .Page.Site.Params.comments.utterances.issueTerm -}}
+{{- $issueLabel := .Page.Site.Params.comments.utterances.issueLabel -}}
 {{- $username := .Page.Site.Params.comments.utterances.github.username -}}
 {{- $repository := .Page.Site.Params.comments.utterances.github.repository -}}
 
 <script src='{{ $scriptSrc }}'
-  repo='{{ print $username "/" $repository }}' issue-term='{{ $issueTerm }}'
+  repo='{{ print $username "/" $repository }}'
+  issue-term='{{ $issueTerm }}'
+  {{- if $issueLabel -}}
+    label='{{ $issueLabel }}'
+  {{- end -}}
   crossorigin='anonymous' async>
 </script>

--- a/layouts/partials/comments/utterances.html
+++ b/layouts/partials/comments/utterances.html
@@ -1,19 +1,19 @@
 {{- $scriptSrc := "https://utteranc.es/client.js" -}}
 
 {{- $issueTerm := .Page.Site.Params.comments.utterances.issueTerm -}}
-{{- $issueLabel := .Page.Site.Params.comments.utterances.issueLabel -}}
+{{- $label := .Page.Site.Params.comments.utterances.label -}}
+{{- $theme := .Page.Site.Params.comments.utterances.theme -}}
 {{- $username := .Page.Site.Params.comments.utterances.github.username -}}
 {{- $repository := .Page.Site.Params.comments.utterances.github.repository -}}
-{{- $theme := .Page.Site.Params.comments.utterances.theme -}}
 
 <script src='{{ $scriptSrc }}'
   repo='{{ print $username "/" $repository }}'
   issue-term='{{ $issueTerm }}'
-  {{- if $issueLabel -}}
-    label='{{ $issueLabel }}'
-  {{- end -}}
-  {{- if $theme -}}
+  {{ if $label -}}
+    label='{{ $label }}'
+  {{- end }}
+  {{ if $theme -}}
     theme="{{ $theme }}"
-  {{- end -}}
+  {{- end }}
   crossorigin='anonymous' async>
 </script>


### PR DESCRIPTION
[Utterances](https://utteranc.es/) commenting system offers two optional fields that provide additional features. I added some functionality to pass config options through to the Utterances script tag in the fields are set.

1. `label` - This field, when set, will automatically add a label to each GitHub issue the Utterances-bot creates. This is handy if you don't want to organize your repo issues. I've tested this functionality on my local machine and it appears to work fine; if no option is passed through from the config files, the template will avoid added the field altogether. This is just to try and keep the rendered HTML looking tidy and avoid any potential edge-cases with Utterances' JavaScript.

2. `theme` - Since the logic for adding the `theme` field is the same as adding the `label` field, I figured I'd add the functionality upstream in case somebody else finds it useful. Personally, I prefer the default Utterances theme so I haven't tested this out too much. If it works like the example on Utterances' website, adding this field might overwrite some theme CSS. This obviously might be a consequence some users don't want... but then again they shouldn't be messing with theme options unless they know what they're doing.

I've updated the default config file and related documentation to reflect these extra options.