### PR TITLE
Avoid printing extra space after shortcode

### DIFF
--- a/layouts/shortcodes/katex.html
+++ b/layouts/shortcodes/katex.html
@@ -2,4 +2,4 @@
 
 {{- print ( cond $displayMode "\\[" "\\(" ) }}
 {{ .Inner }}
-{{ print ( cond $displayMode "\\]" "\\)" ) }}
+{{- print ( cond $displayMode "\\]" "\\)" ) -}}


### PR DESCRIPTION
For inline expressions, this change avoids the insertion of an extra space after the shortcode has been inserted.