### PR TITLE
Fix quote margins

### DIFF
--- a/src/stylesheets/typography/_copy.scss
+++ b/src/stylesheets/typography/_copy.scss
@@ -13,11 +13,17 @@ i {
   font-style: italic;
 }
 
+.quoteblock {
+  .attribution {
+    margin: 0 0 1.5em;
+  }
+}
+
 blockquote {
   @include font-size($font-size__blockquote);
   font-style: italic;
 
-  margin: 0 0 1.5em;
+  margin: 0 0 1em;
   padding-left: 1em;
   border-left: 0.2em solid $color__blockquote-border;
 }


### PR DESCRIPTION
I think this

![image](https://user-images.githubusercontent.com/577360/107254838-c0d05380-6a48-11eb-929b-96de6c7ba10d.png)

looks better than this

![image](https://user-images.githubusercontent.com/577360/107255020-eeb59800-6a48-11eb-9cbf-bf0a492658a7.png)

<1> — margin between text and quote attribution is too big
<2> — there is no margin between quote attribution and following text
