### PR TITLE
Support Google Analytics v4

### DIFF
--- a/layouts/partials/head/analytics.html
+++ b/layouts/partials/head/analytics.html
@@ -1,1 +1,1 @@
-{{- template "_internal/google_analytics_async.html" . -}}
+{{- template "_internal/google_analytics.html" . -}}


### PR DESCRIPTION
In mid 2023, Google Universal Analytics is going to stop functioning. I've switched to the newer `google_analytics.html` template as per the [Hugo docs](https://gohugo.io/templates/internal/#use-the-google-analytics-template_/) and verified this on my personal website, which uses your theme.

What I haven't done is verify that old UA tokens continue to function, but the threads I've read seem to indicate they do.