### PR TITLE
opengraph: LastChange -> Lastmod

### DIFF
--- a/layouts/partials/head/opengraph.html
+++ b/layouts/partials/head/opengraph.html
@@ -97,8 +97,8 @@
     <meta property='article:expiration_time' content='{{ .ExpiryDate.Format $dateFormat }}'/>
   {{- end -}}
 {{- else -}}
-  {{- if not .Site.LastChange.IsZero -}}
-    <meta property='og:updated_time' content='{{ .Site.LastChange.Format $dateFormat }}'/>
+  {{- if not .Site.Lastmod.IsZero -}}
+    <meta property='og:updated_time' content='{{ .Site.Lastmod.Format $dateFormat }}'/>
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Fix this deprecation:

- https://gohugo.io/methods/site/lastchange/

Which prevents builds:

    % hugo
    Start building sites …
    hugo v0.140.1+extended+withdeploy darwin/arm64 BuildDate=unknown VendorInfo=nixpkgs

    ERROR deprecated: .Site.LastChange was deprecated in Hugo v0.123.0 and will be removed in Hugo 0.141.0. Use .Site.Lastmod instead.
    Total in 334 ms
    Error: error building site: logged 1 error(s)